### PR TITLE
refac: refac rw and feature-flags

### DIFF
--- a/crates/protocol-core/Cargo.toml
+++ b/crates/protocol-core/Cargo.toml
@@ -17,9 +17,7 @@ serde_json = "1.0.94"
 hematite-nbt = "0.5.2"
 
 [features]
-packet = [ ]
-rw = []
-rw-sync = [ "rw" ]
-rw-async-tokio = [ "rw", "dep:async-trait", "dep:tokio"] 
-readable = [ "rw" ]
-writeable = [ "rw" ]
+sync = [ ]
+async = [ "dep:async-trait", "dep:tokio"] 
+read = [ ]
+write = [ ]

--- a/crates/protocol-core/src/data/nbt.rs
+++ b/crates/protocol-core/src/data/nbt.rs
@@ -3,8 +3,6 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
-use crate::rw::{Readable, Writeable};
-
 pub struct Nbt<I> {
     inner: I,
 }
@@ -32,12 +30,12 @@ impl<I> DerefMut for Nbt<I> {
     }
 }
 
-#[cfg(all(feature = "rw-sync", not(feature = "rw-async-tokio")))]
-impl<I> Readable for Nbt<I>
+#[cfg(feature = "sync")]
+impl<I> crate::rw::SyncReadable for Nbt<I>
 where
     I: serde::de::DeserializeOwned,
 {
-    fn read<T>(read: &mut T) -> anyhow::Result<Self>
+    fn read_sync<T>(read: &mut T) -> anyhow::Result<Self>
     where
         T: std::io::Read,
     {
@@ -50,12 +48,12 @@ where
     }
 }
 
-#[cfg(all(feature = "rw-sync", not(feature = "rw-async-tokio")))]
-impl<I> Writeable for Nbt<I>
+#[cfg(feature = "sync")]
+impl<I> crate::rw::SyncWriteable for Nbt<I>
 where
     I: serde::Serialize,
 {
-    fn write<T>(&self, mut write: &mut T) -> anyhow::Result<()>
+    fn write_sync<T>(&self, mut write: &mut T) -> anyhow::Result<()>
     where
         T: std::io::Write,
     {
@@ -64,13 +62,13 @@ where
     }
 }
 
-#[cfg(all(feature = "rw-async-tokio", not(feature = "rw-sync")))]
+#[cfg(feature = "async")]
 #[async_trait::async_trait]
-impl<I> Readable for Nbt<I>
+impl<I> crate::rw::AsyncReadable for Nbt<I>
 where
     I: serde::de::DeserializeOwned,
 {
-    async fn read<T>(read: &mut T) -> anyhow::Result<Self>
+    async fn read_async<T>(read: &mut T) -> anyhow::Result<Self>
     where
         T: tokio::io::AsyncRead + std::marker::Unpin + Send + Sync,
     {
@@ -85,13 +83,13 @@ where
     }
 }
 
-#[cfg(all(feature = "rw-async-tokio", not(feature = "rw-sync")))]
+#[cfg(feature = "async")]
 #[async_trait::async_trait]
-impl<I> Writeable for Nbt<I>
+impl<I> crate::rw::AsyncWriteable for Nbt<I>
 where
     I: serde::Serialize + Send + Sync,
 {
-    async fn write<T>(&self, write: &mut T) -> anyhow::Result<()>
+    async fn write_async<T>(&self, write: &mut T) -> anyhow::Result<()>
     where
         T: tokio::io::AsyncWrite + std::marker::Unpin + Send + Sync,
     {

--- a/crates/protocol-core/src/lib.rs
+++ b/crates/protocol-core/src/lib.rs
@@ -1,13 +1,11 @@
-#[cfg(feature = "packet")]
 pub mod packet;
 
-#[cfg(feature = "rw")]
 pub mod rw;
 
 pub mod data;
 
-#[cfg(feature = "rw-async-tokio")]
+#[cfg(feature = "async")]
 pub extern crate tokio;
 
-#[cfg(feature = "rw-async-tokio")]
+#[cfg(feature = "async")]
 pub extern crate async_trait;

--- a/crates/protocol-core/src/rw.rs
+++ b/crates/protocol-core/src/rw.rs
@@ -1,8 +1,12 @@
 cfg_if::cfg_if! {
-    if #[cfg(all(feature = "rw-sync", not(feature = "rw-async-tokio"), any(feature = "readable", feature = "writeable")))] {
+    if #[cfg(feature = "sync")] {
         mod rw_sync;
         pub use rw_sync::*;
-    } else if #[cfg(all(feature = "rw-async-tokio", not(feature = "rw-sync"), any(feature = "readable", feature = "writeable")))] {
+    }
+}
+
+cfg_if::cfg_if! {
+    if #[cfg(feature = "async")] {
         mod rw_async_tokio;
         pub use rw_async_tokio::*;
     }

--- a/crates/protocol-core/src/rw/rw_async_tokio.rs
+++ b/crates/protocol-core/src/rw/rw_async_tokio.rs
@@ -1,16 +1,16 @@
 #[async_trait::async_trait]
-pub trait Readable
+pub trait AsyncReadable
 where
     Self: Sized,
 {
-    async fn read<T>(read: &mut T) -> anyhow::Result<Self>
+    async fn read_async<T>(read: &mut T) -> anyhow::Result<Self>
     where
         T: tokio::io::AsyncRead + std::marker::Unpin + Send + Sync;
 }
 
 #[async_trait::async_trait]
-pub trait Writeable {
-    async fn write<T>(&self, write: &mut T) -> anyhow::Result<()>
+pub trait AsyncWriteable {
+    async fn write_async<T>(&self, write: &mut T) -> anyhow::Result<()>
     where
         T: tokio::io::AsyncWrite + std::marker::Unpin + Send + Sync;
 }

--- a/crates/protocol-core/src/rw/rw_sync.rs
+++ b/crates/protocol-core/src/rw/rw_sync.rs
@@ -1,14 +1,14 @@
-pub trait Readable
+pub trait SyncReadable
 where
     Self: Sized,
 {
-    fn read<T>(read: &mut T) -> anyhow::Result<Self>
+    fn read_sync<T>(read: &mut T) -> anyhow::Result<Self>
     where
         T: std::io::Read;
 }
 
-pub trait Writeable {
-    fn write<T>(&self, write: &mut T) -> anyhow::Result<()>
+pub trait SyncWriteable {
+    fn write_sync<T>(&self, write: &mut T) -> anyhow::Result<()>
     where
         T: std::io::Write;
 }

--- a/crates/protocol-derive/Cargo.toml
+++ b/crates/protocol-derive/Cargo.toml
@@ -18,10 +18,9 @@ quote = "1.0.23"
 cfg-if = "1.0.0"
 
 [features]
-sync = ["packet", "dep:protocol-core", "protocol-core?/rw-sync"]
-async-tokio = ["packet",  "dep:protocol-core", "protocol-core?/rw-async-tokio", "dep:async-trait" ]
-packet = []
-packet-read = ["packet",  "dep:protocol-core", "protocol-core?/readable"]
-packet-write = ["packet",  "dep:protocol-core", "protocol-core?/writeable"]
+sync = ["dep:protocol-core", "protocol-core?/sync"]
+async = ["dep:protocol-core", "protocol-core?/async", "dep:async-trait" ]
+read = ["dep:protocol-core", "protocol-core?/read"]
+write = ["dep:protocol-core", "protocol-core?/write"]
 
 

--- a/crates/protocol-derive/src/features.rs
+++ b/crates/protocol-derive/src/features.rs
@@ -1,16 +1,32 @@
 mod impl_packet;
 pub use impl_packet::impl_packet;
+use syn::DeriveInput;
 
-cfg_if::cfg_if! {
-    if #[cfg(all(feature = "sync", not(feature = "async-tokio")))] {
-        mod impl_readable_sync;
-        pub use impl_readable_sync::impl_readable;
-        mod impl_writeable_sync;
-        pub use impl_writeable_sync::impl_writeable;
-    } else if #[cfg(all(feature = "async-tokio", not(feature = "sync")))] {
-        mod impl_readable_async_tokio;
-        pub use impl_readable_async_tokio::impl_readable;
-        mod impl_writeable_async_tokio;
-        pub use impl_writeable_async_tokio::impl_writeable;
-    }
+mod impl_readable_async;
+mod impl_readable_sync;
+mod impl_writeable_async;
+mod impl_writeable_sync;
+
+pub fn impl_writeable(derive_input: &DeriveInput) -> proc_macro2::TokenStream {
+    let mut stream = proc_macro2::TokenStream::new();
+
+    #[cfg(all(feature = "sync"))]
+    stream.extend_one(impl_writeable_sync::impl_writeable_sync(&derive_input));
+
+    #[cfg(all(feature = "async"))]
+    stream.extend_one(impl_writeable_async::impl_writeable_async(&derive_input));
+
+    stream
+}
+
+pub fn impl_readable(derive_input: &DeriveInput) -> proc_macro2::TokenStream {
+    let mut stream = proc_macro2::TokenStream::new();
+
+    #[cfg(all(feature = "sync"))]
+    stream.extend_one(impl_readable_sync::impl_readable_sync(&derive_input));
+
+    #[cfg(all(feature = "async"))]
+    stream.extend_one(impl_readable_async::impl_readable_async(&derive_input));
+
+    stream
 }

--- a/crates/protocol-derive/src/features/impl_readable_async.rs
+++ b/crates/protocol-derive/src/features/impl_readable_async.rs
@@ -1,7 +1,7 @@
 use quote::quote;
 use syn::PathArguments;
 
-pub fn impl_readable(derive_input: &syn::DeriveInput) -> proc_macro2::TokenStream {
+pub fn impl_readable_async(derive_input: &syn::DeriveInput) -> proc_macro2::TokenStream {
     if let syn::Data::Struct(s) = &derive_input.data {
         let mut result_token_stream = proc_macro2::TokenStream::new();
         let mut create_token_stream = proc_macro2::TokenStream::new();
@@ -17,11 +17,11 @@ pub fn impl_readable(derive_input: &syn::DeriveInput) -> proc_macro2::TokenStrea
                     match &r#type.arguments {
                         PathArguments::AngleBracketed(args) => {
                             result_token_stream.extend_one(quote! {
-                                let #ident = #t_ident::#args::read(read).await?;
+                                let #ident = #t_ident::#args::read_async(read).await?;
                             })
                         }
                         _ => result_token_stream.extend_one(quote! {
-                            let #ident = #t_ident::read(read).await?;
+                            let #ident = #t_ident::read_async(read).await?;
                         }),
                     };
                     create_token_stream.extend_one(quote! { #ident, })
@@ -36,12 +36,12 @@ pub fn impl_readable(derive_input: &syn::DeriveInput) -> proc_macro2::TokenStrea
 
         let tokens = quote! {
             #[async_trait::async_trait]
-            impl protocol_core::rw::Readable for #ident {
-                async fn read<T>(read: &mut T) -> anyhow::Result<Self>
+            impl protocol_core::rw::AsyncReadable for #ident {
+                async fn read_async<T>(read: &mut T) -> anyhow::Result<Self>
                 where
                     T: tokio::io::AsyncRead + std::marker::Unpin + Send + Sync
                 {
-                    use protocol_core::rw::Readable;
+                    use protocol_core::rw::AsyncReadable;
 
                     #result_token_stream
 

--- a/crates/protocol-derive/src/features/impl_readable_sync.rs
+++ b/crates/protocol-derive/src/features/impl_readable_sync.rs
@@ -1,7 +1,7 @@
 use quote::quote;
 use syn::PathArguments;
 
-pub fn impl_readable(derive_input: &syn::DeriveInput) -> proc_macro2::TokenStream {
+pub fn impl_readable_sync(derive_input: &syn::DeriveInput) -> proc_macro2::TokenStream {
     if let syn::Data::Struct(s) = &derive_input.data {
         let mut result_token_stream = proc_macro2::TokenStream::new();
         let mut create_token_stream = proc_macro2::TokenStream::new();
@@ -14,11 +14,11 @@ pub fn impl_readable(derive_input: &syn::DeriveInput) -> proc_macro2::TokenStrea
                     match &r#type.arguments {
                         PathArguments::AngleBracketed(args) => {
                             result_token_stream.extend_one(quote! {
-                                let #ident = #t_ident::#args::read(read)?;
+                                let #ident = #t_ident::#args::read_sync(read)?;
                             })
                         }
                         _ => result_token_stream.extend_one(quote! {
-                            let #ident = #t_ident::read(read)?;
+                            let #ident = #t_ident::read_sync(read)?;
                         }),
                     };
                     create_token_stream.extend_one(quote! { #ident, })
@@ -32,12 +32,12 @@ pub fn impl_readable(derive_input: &syn::DeriveInput) -> proc_macro2::TokenStrea
         let ident = &derive_input.ident;
 
         let tokens = quote! {
-            impl protocol_core::rw::Readable for #ident {
-                fn read<T>(read: &mut T) -> anyhow::Result<Self>
+            impl protocol_core::rw::SyncReadable for #ident {
+                fn read_sync<T>(read: &mut T) -> anyhow::Result<Self>
                 where
                     T: std::io::Read
                 {
-                    use protocol_core::rw::Readable;
+                    use protocol_core::rw::SyncReadable;
 
                     #result_token_stream
 

--- a/crates/protocol-derive/src/features/impl_writeable_async.rs
+++ b/crates/protocol-derive/src/features/impl_writeable_async.rs
@@ -1,6 +1,6 @@
 use quote::quote;
 
-pub fn impl_writeable(derive_input: &syn::DeriveInput) -> proc_macro2::TokenStream {
+pub fn impl_writeable_async(derive_input: &syn::DeriveInput) -> proc_macro2::TokenStream {
     if let syn::Data::Struct(s) = &derive_input.data {
         let mut result_token_stream = proc_macro2::TokenStream::new();
         for field in &s.fields {
@@ -8,7 +8,7 @@ pub fn impl_writeable(derive_input: &syn::DeriveInput) -> proc_macro2::TokenStre
                 syn::Type::Path(_) => {
                     let ident = &field.ident;
                     result_token_stream.extend_one(quote! {
-                        self.#ident.write(write).await?;
+                        self.#ident.write_async(write).await?;
                     });
                 }
                 _ => {
@@ -21,12 +21,12 @@ pub fn impl_writeable(derive_input: &syn::DeriveInput) -> proc_macro2::TokenStre
 
         let tokens = quote! {
             #[async_trait::async_trait]
-            impl protocol_core::rw::Writeable for #ident {
-                async fn write<T>(&self, write: &mut T) -> anyhow::Result<()>
+            impl protocol_core::rw::AsyncWriteable for #ident {
+                async fn write_async<T>(&self, write: &mut T) -> anyhow::Result<()>
                 where
                     T: tokio::io::AsyncWrite + std::marker::Unpin + Send + Sync
                 {
-                    use protocol_core::rw::Writeable;
+                    use protocol_core::rw::AsyncWriteable;
 
                     #result_token_stream
 

--- a/crates/protocol-derive/src/features/impl_writeable_sync.rs
+++ b/crates/protocol-derive/src/features/impl_writeable_sync.rs
@@ -1,6 +1,6 @@
 use quote::quote;
 
-pub fn impl_writeable(derive_input: &syn::DeriveInput) -> proc_macro2::TokenStream {
+pub fn impl_writeable_sync(derive_input: &syn::DeriveInput) -> proc_macro2::TokenStream {
     if let syn::Data::Struct(s) = &derive_input.data {
         let mut result_token_stream = proc_macro2::TokenStream::new();
         for field in &s.fields {
@@ -8,7 +8,7 @@ pub fn impl_writeable(derive_input: &syn::DeriveInput) -> proc_macro2::TokenStre
                 syn::Type::Path(_) => {
                     let ident = &field.ident;
                     result_token_stream.extend_one(quote! {
-                        self.#ident.write(write)?;
+                        self.#ident.write_sync(write)?;
                     });
                 }
                 _ => {
@@ -20,12 +20,12 @@ pub fn impl_writeable(derive_input: &syn::DeriveInput) -> proc_macro2::TokenStre
         let ident = &derive_input.ident;
 
         let tokens = quote! {
-            impl protocol_core::rw::Writeable for #ident {
-                fn write<T>(&self, write: &mut T) -> anyhow::Result<()>
+            impl protocol_core::rw::SyncWriteable for #ident {
+                fn write_sync<T>(&self, write: &mut T) -> anyhow::Result<()>
                 where
                     T: std::io::Write
                 {
-                    use protocol_core::rw::Writeable;
+                    use protocol_core::rw::SyncWriteable;
 
                     #result_token_stream
 

--- a/crates/protocol-derive/src/impls/derive_packet_impl.rs
+++ b/crates/protocol-derive/src/impls/derive_packet_impl.rs
@@ -3,11 +3,11 @@ pub fn derive_packet_impl(token_stream: proc_macro::TokenStream) -> proc_macro::
     let mut result_token_stream = proc_macro2::TokenStream::new();
 
     result_token_stream.extend_one(crate::features::impl_packet(&derive_input));
-    if cfg!(feature = "packet-write") {
+    if cfg!(feature = "write") {
         result_token_stream.extend_one(crate::features::impl_writeable(&derive_input));
     }
 
-    if cfg!(feature = "packet-read") {
+    if cfg!(feature = "read") {
         result_token_stream.extend_one(crate::features::impl_readable(&derive_input));
     }
 

--- a/crates/protocol-derive/src/lib.rs
+++ b/crates/protocol-derive/src/lib.rs
@@ -4,7 +4,6 @@
 mod features;
 mod impls;
 
-#[cfg(feature = "packet")]
 #[proc_macro_derive(Packet, attributes(packet_id, varint, varlong))]
 pub fn derive_packet(token_stream: proc_macro::TokenStream) -> proc_macro::TokenStream {
     impls::derive_packet_impl(token_stream)

--- a/crates/protocol-packets/Cargo.toml
+++ b/crates/protocol-packets/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-protocol-core = { path = "../protocol-core", features = [ "packet" ] }
-protocol-derive = { path = "../protocol-derive", features = [ "packet" ] }
+protocol-core = { path = "../protocol-core" }
+protocol-derive = { path = "../protocol-derive" }
 anyhow = "1.0.69"
 trust-dns-resolver = "0.22.0"
 integer-encoding = "3.0.4"
@@ -18,8 +18,8 @@ async-trait = { version = "0.1.66", optional = true }
 tokio = {version = "1.26.0", optional = true }
 
 [features]
-default = [ "read", "write", "sync" ]
-read = [ "protocol-core/readable", "protocol-derive/packet-read" ]
-write = [ "protocol-core/writeable", "protocol-derive/packet-write" ]
-sync = [ "protocol-core/rw-sync", "protocol-derive/sync" ]
-async-tokio = [ "protocol-core/rw-async-tokio", "protocol-derive/async-tokio", "dep:async-trait", "dep:tokio" ]
+default = [ "read", "write", "async-tokio" ]
+read = [ "protocol-core/read", "protocol-derive/read" ]
+write = [ "protocol-core/write", "protocol-derive/write" ]
+sync = [ "protocol-core/sync", "protocol-derive/sync" ]
+async-tokio = [ "protocol-core/async", "protocol-derive/async", "dep:async-trait", "dep:tokio" ]

--- a/examples/sync-status/Cargo.toml
+++ b/examples/sync-status/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-protocol-packets = { path = "../../crates/protocol-packets", default-features = false}
+protocol-packets = { path = "../../crates/protocol-packets", default-features = false, features = [ "read", "write", "sync" ] }


### PR DESCRIPTION
This PR changes the way the feature-flags works with the Readable and Writeable traits.

### before

It used to export a different definition for the trait based on the flags `rw-sync` and `rw-async-tokio`(with read and write methods for bot definitions), but that was conflicting with the examples and it were kind of ugly.

### now

Now there's two sets of traits, `SyncReadable`/`SyncWriteable` (with read_sync and write_sync methods, respectively) and `AsyncReadable`/`AsyncWriteable` (with read_async and write_async methods, respectively) that gets exported with the feature flags `sync` and `async` respectively. 
It means that now someone could (for some reason) have both sync and async methods for packets on the same project.

### bonus
Some useless feature-flags were removed across all 3 crates to make things simpler.